### PR TITLE
Add a writer module to transform the instructions back to binary

### DIFF
--- a/desc/core.desc
+++ b/desc/core.desc
@@ -27,7 +27,7 @@ group Extension;
 group Mode;
 14  MemoryModel addressing-model memory-model;
 15  EntryPoint execution-model func:value-id name:string interface:[id];
-16  ExecutionMode execution-mode;
+16  ExecutionMode entry:value-id execution-mode;
 17  Capability capability;
 
 group Type;

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -256,4 +256,8 @@ impl ImageOperands {
 
         idx
     }
+
+    pub fn to_desc(&self) -> desc::ImageOperands {
+        self.set
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ use std::path::Path;
 pub mod desc;
 pub mod instruction;
 pub mod parse;
+pub mod write;
 
 use desc::Id;
 use instruction::Instruction;

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,0 +1,41 @@
+use ::instruction::{Instruction, Decoration};
+use ::parse::RawInstruction;
+use ::desc::Op;
+
+#[derive(Default)]
+struct StringBuilder {
+    words: Vec<u32>,
+    bytes: Vec<u8>,
+}
+
+impl StringBuilder {
+    /// Turns a `String` into a padded list of 32-bits words
+    pub fn to_words(string: String) -> Vec<u32> {
+        let mut builder: StringBuilder = Default::default();
+
+        for byte in string.as_bytes() {
+            builder.push_byte(*byte);
+        }
+
+        builder.push_byte(0);
+        while builder.bytes.len() != 0 {
+            builder.push_byte(0);
+        }
+
+        builder.words
+    }
+
+    fn push_byte(&mut self, byte: u8) {
+        self.bytes.push(byte);
+        if self.bytes.len() == 4 {
+            unsafe {
+                let arr = self.bytes.as_ptr() as *const [u8; 4];
+                self.words.push(::std::mem::transmute(*arr));
+            }
+
+            self.bytes.clear();
+        }
+    }
+}
+
+include!(concat!(env!("OUT_DIR"), "/inst_writer.rs"));


### PR DESCRIPTION
This PR adds a new `write` module exposing a single function to turn Instructions back to a binary form (`fn to_bytecode(inst: Instruction) -> Vec<u32>`), generated by a new build script function.

Additionally from the small edits I had to do on the actual code to make it work, I also had to change the definition of ExecutionMode to make it match the specifications.